### PR TITLE
Use tqdm to log progress

### DIFF
--- a/datasets/fuss/make_ss_examples.py
+++ b/datasets/fuss/make_ss_examples.py
@@ -25,6 +25,7 @@ import os
 
 import numpy as np
 import scaper
+from tqdm import tqdm
 
 from utils import check_and_correct_example
 
@@ -138,8 +139,8 @@ class Mixer(object):
     self.sc.ref_db = self.ref_db
     self.sc.sr = self.sample_rate
 
-    for n in range(num_examps):
-      print('Generating example: {:d}/{:d}'.format(n+1, num_examps))
+    for n in tqdm(range(num_examps)):
+      # print('Generating example: {:d}/{:d}'.format(n+1, num_examps))
       example, ind_fg, ind_bg = self.generate_example(
           subset, n, num_examps, bg_file_list, fg_file_list,
           ind_fg, ind_bg)

--- a/datasets/fuss/requirements.txt
+++ b/datasets/fuss/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+argparse
+soundfile
+scaper
+tqdm


### PR DESCRIPTION
Hi Scott, 

Thanks for the scripts and the dataset !
 I wonder if you'd consider using `tqdm` to log the mixture generation progress instead of writing one line per generated mixture. 
It'll make the log file much more readable, and that's valuable IMO. 

I also added a requirements.txt, but you can remove it if you think it's not useful. 

Thanks